### PR TITLE
fix broken IMU and mag msg timestamps

### DIFF
--- a/src/bno08x_ros.cpp
+++ b/src/bno08x_ros.cpp
@@ -207,8 +207,7 @@ void BNO08xROS::sensor_callback(void *cookie, sh2_SensorValue_t *sensor_value) {
 			this->mag_msg_.magnetic_field.y = sensor_value->un.magneticField.y;
 			this->mag_msg_.magnetic_field.z = sensor_value->un.magneticField.z;
 			this->mag_msg_.header.frame_id = this->frame_id_;
-			this->mag_msg_.header.stamp.sec = this->get_clock()->now().seconds();
-			this->mag_msg_.header.stamp.nanosec = this->get_clock()->now().nanoseconds();
+			this->mag_msg_.header.stamp = this->get_clock()->now();
 			// IMU will still return infrequent magnetic field reports even if the report
 			// was not enabled, so check it was enabled before publishing.
 			if (publish_magnetic_field_) {
@@ -240,8 +239,7 @@ void BNO08xROS::sensor_callback(void *cookie, sh2_SensorValue_t *sensor_value) {
 
 	if(imu_received_flag_ == (ROTATION_VECTOR_RECEIVED | ACCELEROMETER_RECEIVED | GYROSCOPE_RECEIVED)){
 		this->imu_msg_.header.frame_id = this->frame_id_;
-		this->imu_msg_.header.stamp.sec = this->get_clock()->now().seconds();
-		this->imu_msg_.header.stamp.nanosec = this->get_clock()->now().nanoseconds();
+		this->imu_msg_.header.stamp = this->get_clock()->now();
 		this->imu_publisher_->publish(this->imu_msg_);
 		imu_received_flag_ = 0;
 	}


### PR DESCRIPTION
The previous code called get_clock()->now() twice — once for sec and once for nanosec — meaning the two fields could come from different instants. It also used .seconds() (returns double, loses sub-second precision) and .nanoseconds() (returns total nanoseconds since epoch, not the sub-second component). This makes a 3-4s jump confusing the EKF filter.

Assign the rclcpp::Time value directly to header.stamp in a single call, which correctly populates both fields atomically.

Resolves #20

Thank you @sicarius666 for reporting.