### PR TITLE
add configurable covariance matrices for IMU msgs

### DIFF
--- a/config/bno085_i2c.yaml
+++ b/config/bno085_i2c.yaml
@@ -4,7 +4,7 @@ bno08x_driver:
     frame_id: "bno085"  # The frame_id to use for the sensor data
 
     # Communication Interface
-    # Select the communication interface to use 
+    # Select the communication interface to use
     # (only one interface can be enabled at a time)
     # This requires a hardware change to the board
     # (see documentation for more information)
@@ -14,10 +14,18 @@ bno08x_driver:
       address: "0x4A"
 
     publish:
-      magnetic_field: 
+      magnetic_field:
         enabled: true
         rate: 100   # max 100 Hz
       imu:
         enabled: true
-        rate: 100   # max 400 Hz 
-                    # (anythihng above 100Hz depends on your hardware)
+        rate: 100   # max 400 Hz (anything above 100Hz depends on your hardware)
+        orientation_covariance: [3.73e-3, 0.0, 0.0,
+                                 0.0, 3.73e-3, 0.0,
+                                 0.0, 0.0, 3.73e-3]
+        gyrometer_covariance:   [2.93e-3, 0.0, 0.0,
+                                 0.0, 2.93e-3, 0.0,
+                                 0.0, 0.0, 2.93e-3]
+        linear_covariance:      [0.1225, 0.0, 0.0,
+                                 0.0, 0.1225, 0.0,
+                                 0.0, 0.0, 0.1225]

--- a/include/bno08x_driver/bno08x_ros.hpp
+++ b/include/bno08x_driver/bno08x_ros.hpp
@@ -1,16 +1,14 @@
 #pragma once
 
 #include <mutex>
-#include <chrono>
-#include <functional>
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/logging.hpp>
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
 #include <sensor_msgs/msg/imu.hpp>
-#include <rcl_interfaces/msg/parameter_descriptor.hpp>
+
 #include "bno08x_driver/bno08x.hpp"
-#include "bno08x_driver/logger.h"
 #include "bno08x_driver/watchdog.hpp"
-#include "sh2/sh2.h"
 
 class BNO08xROS : public rclcpp::Node
 {
@@ -23,6 +21,7 @@ private:
     void init_comms();
     void init_parameters();
     void init_sensor();
+    void init_imu_covariance();
     void poll_timer_callback();
     void reset();
 
@@ -54,5 +53,28 @@ private:
     bool publish_orientation_;
     bool publish_acceleration_;
     bool publish_angular_velocity_;
-};
 
+    std::vector<double> orientation_covariance_;
+    std::vector<double> gyrometer_covariance_;
+    std::vector<double> linear_covariance_;
+
+    // Default covariance values derived from datasheet noise figures.
+    // Orientation: 3.5 deg RMS -> variance in rad^2
+    const std::vector<double> default_orientation_covariance_ = {
+        pow(3.5 * M_PI / 180, 2), 0, 0,
+        0, pow(3.5 * M_PI / 180, 2), 0,
+        0, 0, pow(3.5 * M_PI / 180, 2)
+    };
+    // Gyroscope: 3.1 deg/s RMS -> variance in (rad/s)^2
+    const std::vector<double> default_gyrometer_covariance_ = {
+        pow(3.1 * M_PI / 180, 2), 0, 0,
+        0, pow(3.1 * M_PI / 180, 2), 0,
+        0, 0, pow(3.1 * M_PI / 180, 2)
+    };
+    // Accelerometer: 0.35 m/s^2 RMS -> variance in (m/s^2)^2
+    const std::vector<double> default_linear_covariance_ = {
+        pow(0.35, 2), 0, 0,
+        0, pow(0.35, 2), 0,
+        0, 0, pow(0.35, 2)
+    };
+};

--- a/src/bno08x_ros.cpp
+++ b/src/bno08x_ros.cpp
@@ -3,6 +3,8 @@
 #include "bno08x_driver/uart_interface.hpp"
 #include "bno08x_driver/spi_interface.hpp"
 
+#include <cmath>
+
 constexpr uint8_t ROTATION_VECTOR_RECEIVED = 0x01;
 constexpr uint8_t ACCELEROMETER_RECEIVED   = 0x02;
 constexpr uint8_t GYROSCOPE_RECEIVED       = 0x04;
@@ -15,6 +17,7 @@ BNO08xROS::BNO08xROS()
     this->init_sensor();
 
     if (publish_imu_) {
+        this->init_imu_covariance();
         this->imu_publisher_ = this->create_publisher<sensor_msgs::msg::Imu>("/imu", 10);
         RCLCPP_INFO(this->get_logger(), "IMU Publisher created");
         RCLCPP_INFO(this->get_logger(), "IMU Rate: %d", imu_rate_);
@@ -126,6 +129,9 @@ void BNO08xROS::init_parameters() {
     this->declare_parameter<int>("publish.magnetic_field.rate", 100);
     this->declare_parameter<bool>("publish.imu.enabled", true);
     this->declare_parameter<int>("publish.imu.rate", 100);
+    this->declare_parameter<std::vector<double>>("publish.imu.orientation_covariance", this->default_orientation_covariance_);
+    this->declare_parameter<std::vector<double>>("publish.imu.gyrometer_covariance", this->default_gyrometer_covariance_);
+    this->declare_parameter<std::vector<double>>("publish.imu.linear_covariance", this->default_linear_covariance_);
 
     this->declare_parameter<bool>("i2c.enabled", true);
     this->declare_parameter<std::string>("i2c.bus", "/dev/i2c-7");
@@ -141,6 +147,27 @@ void BNO08xROS::init_parameters() {
     this->get_parameter("publish.magnetic_field.rate", magnetic_field_rate_);
     this->get_parameter("publish.imu.enabled", publish_imu_);
     this->get_parameter("publish.imu.rate", imu_rate_);
+
+    this->get_parameter("publish.imu.orientation_covariance", orientation_covariance_);
+    if (orientation_covariance_.size() != 9) {
+        RCLCPP_WARN(this->get_logger(),
+            "publish.imu.orientation_covariance must be a 9-element array, using defaults.");
+        orientation_covariance_ = default_orientation_covariance_;
+    }
+
+    this->get_parameter("publish.imu.gyrometer_covariance", gyrometer_covariance_);
+    if (gyrometer_covariance_.size() != 9) {
+        RCLCPP_WARN(this->get_logger(),
+            "publish.imu.gyrometer_covariance must be a 9-element array, using defaults.");
+        gyrometer_covariance_ = default_gyrometer_covariance_;
+    }
+
+    this->get_parameter("publish.imu.linear_covariance", linear_covariance_);
+    if (linear_covariance_.size() != 9) {
+        RCLCPP_WARN(this->get_logger(),
+            "publish.imu.linear_covariance must be a 9-element array, using defaults.");
+        linear_covariance_ = default_linear_covariance_;
+    }
 }
 
 /**
@@ -189,7 +216,17 @@ void BNO08xROS::init_sensor() {
         RCLCPP_ERROR(this->get_logger(), "No sensor reports enabled! Exiting...");
         throw std::runtime_error("No sensor reports enabled");
     }
-}   
+}
+
+void BNO08xROS::init_imu_covariance()
+{
+    std::copy(orientation_covariance_.begin(), orientation_covariance_.end(),
+              imu_msg_.orientation_covariance.begin());
+    std::copy(gyrometer_covariance_.begin(), gyrometer_covariance_.end(),
+              imu_msg_.angular_velocity_covariance.begin());
+    std::copy(linear_covariance_.begin(), linear_covariance_.end(),
+              imu_msg_.linear_acceleration_covariance.begin());
+}
 
 /**
  * @brief Callback function for sensor events


### PR DESCRIPTION
Populate all three sensor_msgs/Imu covariance matrices from ROS2 parameters so that robot_localization and other EKF nodes can weight IMU readings correctly. Default values are derived from BNO08x datasheet noise figures (3.5 deg orientation RMS, 3.1 deg/s gyro RMS, 0.35 m/s^2 accel RMS). All three matrices are user-overridable via YAML config.

Resolves #17